### PR TITLE
Test coverage for ref structs

### DIFF
--- a/TestComponent/TestComponent.idl
+++ b/TestComponent/TestComponent.idl
@@ -41,9 +41,9 @@ namespace TestComponent
     delegate Double Param10Handler(Double a, out Double b);
     delegate Char Param11Handler(Char a, out Char b);
     delegate String Param12Handler(String a, out String b);
-    delegate Blittable Param13Handler(Blittable a, out Blittable b);
-    delegate NonBlittable Param14Handler(NonBlittable a, out NonBlittable b);
-    delegate Nested Param15Handler(Nested a, out Nested b);
+    delegate Blittable Param13Handler(Blittable a, ref const Blittable b, out Blittable c);
+    delegate NonBlittable Param14Handler(NonBlittable a, ref const NonBlittable b, out NonBlittable c);
+    delegate Nested Param15Handler(Nested a, ref const Nested b, out Nested c);
 
     delegate Boolean[] Array1Handler(Boolean[] a, ref Boolean[] b, out Boolean[] c);
     delegate UInt8[] Array2Handler(UInt8[] a, ref UInt8[] b, out UInt8[] c);
@@ -90,9 +90,9 @@ namespace TestComponent
         Double Param10(Double a, out Double b);
         Char Param11(Char a, out Char b);
         String Param12(String a, out String b);
-        Blittable Param13(Blittable a, out Blittable b);
-        NonBlittable Param14(NonBlittable a, out NonBlittable b);
-        Nested Param15(Nested a, out Nested b);
+        Blittable Param13(Blittable a, ref const Blittable b, out Blittable c);
+        NonBlittable Param14(NonBlittable a, ref const NonBlittable b, out NonBlittable c);
+        Nested Param15(Nested a, ref const Nested b, out Nested c);
 
         void Param1Call(Param1Handler handler);
         void Param2Call(Param2Handler handler);

--- a/TestComponent/TestRunner.cpp
+++ b/TestComponent/TestRunner.cpp
@@ -10,11 +10,6 @@ using namespace Windows::Foundation::Collections;
 
 #define TEST_REQUIRE(message, expression) { if (!(expression)) throw hresult_invalid_argument(message); }
 
-bool pair_equal(IKeyValuePair<hstring, hstring> const& left, IKeyValuePair<hstring, hstring> const& right)
-{
-    return left.Key() == right.Key() && left.Value() == right.Value();
-}
-
 IAsyncAction SignalAsync(HANDLE event)
 {
     co_await resume_on_signal(event);
@@ -274,8 +269,8 @@ namespace winrt::TestComponent::implementation
             IIterable<IKeyValuePair<hstring, hstring>> b;
             IIterable<IKeyValuePair<hstring, hstring>> c = handler(a, b);
             TEST_REQUIRE_N(L"Collection", 2, a != b && a != c);
-            TEST_REQUIRE_N(L"Collection", 2, std::equal(begin(a), end(a), begin(b), end(b), pair_equal));
-            TEST_REQUIRE_N(L"Collection", 2, std::equal(begin(a), end(a), begin(c), end(c), pair_equal));
+            TEST_REQUIRE_N(L"Collection", 2, std::equal(begin(a), end(a), begin(b), end(b)));
+            TEST_REQUIRE_N(L"Collection", 2, std::equal(begin(a), end(a), begin(c), end(c)));
         }
         void Collection3Call(Collection3Handler const& handler)
         {
@@ -283,8 +278,8 @@ namespace winrt::TestComponent::implementation
             IMap<hstring, hstring> b;
             IMap<hstring, hstring> c = handler(a, b);
             TEST_REQUIRE_N(L"Collection", 3, a != b && a != c);
-            TEST_REQUIRE_N(L"Collection", 3, std::equal(begin(a), end(a), begin(b), end(b), pair_equal));
-            TEST_REQUIRE_N(L"Collection", 3, std::equal(begin(a), end(a), begin(c), end(c), pair_equal));
+            TEST_REQUIRE_N(L"Collection", 3, std::equal(begin(a), end(a), begin(b), end(b)));
+            TEST_REQUIRE_N(L"Collection", 3, std::equal(begin(a), end(a), begin(c), end(c)));
         }
         void Collection4Call(Collection4Handler const& handler)
         {
@@ -292,8 +287,8 @@ namespace winrt::TestComponent::implementation
             IMapView<hstring, hstring> b;
             IMapView<hstring, hstring> c = handler(a, b);
             TEST_REQUIRE_N(L"Collection", 4, a != b && a != c);
-            TEST_REQUIRE_N(L"Collection", 4, std::equal(begin(a), end(a), begin(b), end(b), pair_equal));
-            TEST_REQUIRE_N(L"Collection", 4, std::equal(begin(a), end(a), begin(c), end(c), pair_equal));
+            TEST_REQUIRE_N(L"Collection", 4, std::equal(begin(a), end(a), begin(b), end(b)));
+            TEST_REQUIRE_N(L"Collection", 4, std::equal(begin(a), end(a), begin(c), end(c)));
         }
         void Collection5Call(Collection5Handler const& handler)
         {

--- a/TestComponent/TestRunner.cpp
+++ b/TestComponent/TestRunner.cpp
@@ -76,7 +76,6 @@ namespace winrt::TestComponent::implementation
         TEST_GEN(9, float);
         TEST_GEN(10, double);
         TEST_GEN(11, char16_t);
-        TEST_GEN(13, Blittable);
 
 #undef TEST_GEN
 
@@ -88,16 +87,24 @@ namespace winrt::TestComponent::implementation
             b = a;
             return a;
         }
-        auto Param14(NonBlittable const& a, NonBlittable& b)
+        auto Param13(Blittable const& a, Blittable const& b, Blittable& c)
         {
-            TEST_REQUIRE_N(L"Param", 14, b == NonBlittable{});
-            b = a;
+            TEST_REQUIRE_N(L"Param", 13, a == b);
+            c = a;
             return a;
         }
-        auto Param15(Nested const& a, Nested& b)
+        auto Param14(NonBlittable const& a, NonBlittable const& b, NonBlittable& c)
         {
-            TEST_REQUIRE_N(L"Param", 15, b == Nested{});
-            b = a;
+            TEST_REQUIRE_N(L"Param", 14, a == b);
+            TEST_REQUIRE_N(L"Param", 14, c == NonBlittable{});
+            c = a;
+            return a;
+        }
+        auto Param15(Nested const& a, Nested const& b, Nested& c)
+        {
+            TEST_REQUIRE_N(L"Param", 14, a == b);
+            TEST_REQUIRE_N(L"Param", 15, c == Nested{});
+            c = a;
             return a;
         }
 
@@ -123,6 +130,18 @@ namespace winrt::TestComponent::implementation
         TEST_GEN(11, char16_t, L'W');
         // TODO: do these also need non-blittable out param testing?
         TEST_GEN(12, hstring, L"WinRT");
+
+#undef TEST_GEN
+
+#define TEST_GEN(number, type, value) \
+    void Param ## number ## Call(Param ## number ## Handler const& handler) \
+    { \
+        type const a = value; \
+        type b; \
+        type c = handler(a, a, b); \
+        TEST_REQUIRE_N(L"Param", number, a == b && a == c); \
+    }
+
         TEST_GEN(13, Blittable, (Blittable{ false, 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'X', guid_of<ITests>() }));
         TEST_GEN(14, NonBlittable, (NonBlittable{ L"WinRT", 1234 }));
         TEST_GEN(15, Nested, (Nested{ { false, 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'X', guid_of<ITests>() }, { L"WinRT", 1234 } }));


### PR DESCRIPTION
In MIDL parlance, a "ref const" parameter is limited to structs and constitutes a struct input parameter that is passed by address rather than by value (the default).