### PR TITLE
'a' test array was not being correctly constructed

### DIFF
--- a/TestComponent/TestRunner.cpp
+++ b/TestComponent/TestRunner.cpp
@@ -173,33 +173,36 @@ namespace winrt::TestComponent::implementation
 
 #undef TEST_GEN
 
-#define TEST_GEN(number, type, value) \
-    void Array ## number ## Call(Array ## number ## Handler const& handler) \
-    { \
-        std::array<type, 3> a { value }; \
-        std::array<type, 3> b; \
-        com_array<type> c; \
-        com_array<type> d = handler(a, b, c); \
-        TEST_REQUIRE_N(L"Array", number, std::equal(a.begin(), a.end(), b.begin(), b.end())); \
-        TEST_REQUIRE_N(L"Array", number, std::equal(a.begin(), a.end(), c.begin(), c.end())); \
-        TEST_REQUIRE_N(L"Array", number, std::equal(a.begin(), a.end(), d.begin(), d.end())); \
+    template<typename type, typename ArrayHandler>
+    void ArrayCall(std::array<type, 3> a, size_t number, ArrayHandler const& handler)
+    {
+        std::array<type, 3> b; 
+        com_array<type> c; 
+        com_array<type> d = handler(a, b, c); 
+        TEST_REQUIRE_N(L"Array", number, std::equal(a.begin(), a.end(), b.begin(), b.end())); 
+        TEST_REQUIRE_N(L"Array", number, std::equal(a.begin(), a.end(), c.begin(), c.end())); 
+        TEST_REQUIRE_N(L"Array", number, std::equal(a.begin(), a.end(), d.begin(), d.end())); 
     }
 
-        TEST_GEN(1, bool, (true, false, true));
-        TEST_GEN(2, uint8_t, (1, 2, 3));
-        TEST_GEN(3, uint16_t, (4, 5, 7));
-        TEST_GEN(4, uint32_t, (7, 8, 9));
-        TEST_GEN(5, uint64_t, (1, 2, 3));
-        TEST_GEN(6, int16_t, (4, 5, 7));
-        TEST_GEN(7, int32_t, (7, 8, 9));
-        TEST_GEN(8, int64_t, (1, 2, 3));
-        TEST_GEN(9, float, (1.0f, 2.0f, 3.0f));
-        TEST_GEN(10, double, (4.0f, 5.0f, 6.0f));
-        TEST_GEN(11, char16_t, (L'W', L'i', L'n'));
-        TEST_GEN(12, hstring, (L"C++", L"C#", L"Rust"));
-        TEST_GEN(13, Blittable, (Blittable{ 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'X', guid_of<ITests>() }, Blittable{ 10, 20, 30, 40, -50, -60, -70, 80.0f, 90.0, L'Y', guid_of<IStringable>() }, Blittable{ 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'Z', guid_of<IInspectable>() }));
-        TEST_GEN(14, NonBlittable, (NonBlittable{ false, L"First", 123 }, NonBlittable{ true, L"Second", 456 }, NonBlittable{ false, L"Third", 789 }));
-        TEST_GEN(15, Nested, (Nested{ { 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'X', guid_of<ITests>() }, { false, L"First", 123 } }, Nested{ { 10, 20, 30, 40, -50, -60, -70, 80.0f, 90.0, L'Y', guid_of<IStringable>() }, { true, L"Second", 456 } }, Nested{ { 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'Z', guid_of<IInspectable>() }, { false, L"Third", 789 } }));
+#define TEST_GEN(number, type, ...) \
+    void Array ## number ## Call(Array ## number ## Handler const& handler) \
+        { ArrayCall<type>({ __VA_ARGS__ }, number, handler); }
+
+        TEST_GEN(1, bool, true, false, true);
+        TEST_GEN(2, uint8_t, 1, 2, 3);
+        TEST_GEN(3, uint16_t, 4, 5, 7);
+        TEST_GEN(4, uint32_t, 7, 8, 9);
+        TEST_GEN(5, uint64_t, 1, 2, 3);
+        TEST_GEN(6, int16_t, 4, 5, 7);
+        TEST_GEN(7, int32_t, 7, 8, 9);
+        TEST_GEN(8, int64_t, 1, 2, 3);
+        TEST_GEN(9, float, 1.0f, 2.0f, 3.0f);
+        TEST_GEN(10, double, 4.0f, 5.0f, 6.0f);
+        TEST_GEN(11, char16_t, L'W', L'i', L'n');
+        TEST_GEN(12, hstring, L"C++", L"C#", L"Rust");
+        TEST_GEN(13, Blittable, Blittable{ 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'X', guid_of<ITests>() }, Blittable{ 10, 20, 30, 40, -50, -60, -70, 80.0f, 90.0, L'Y', guid_of<IStringable>() }, Blittable{ 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'Z', guid_of<IInspectable>() });
+        TEST_GEN(14, NonBlittable, NonBlittable{ false, L"First", 123 }, NonBlittable{ true, L"Second", 456 }, NonBlittable{ false, L"Third", 789 });
+        TEST_GEN(15, Nested, Nested{ { 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'X', guid_of<ITests>() }, { false, L"First", 123 } }, Nested{ { 10, 20, 30, 40, -50, -60, -70, 80.0f, 90.0, L'Y', guid_of<IStringable>() }, { true, L"Second", 456 } }, Nested{ { 1, 2, 3, 4, -5, -6, -7, 8.0f, 9.0, L'Z', guid_of<IInspectable>() }, { false, L"Third", 789 } });
 
 #undef TEST_GEN
 


### PR DESCRIPTION
commas in initialization list were being interpreted as the comma operator, so only the third element was being populated in the first slot, with zero-filled remainder.  also de-macro'd the implementation to make it debuggable.