### PR TITLE
Adding a component for benchmarks.

### DIFF
--- a/BenchmarkComponent/BenchmarkComponent.cpp
+++ b/BenchmarkComponent/BenchmarkComponent.cpp
@@ -1,0 +1,64 @@
+#include "pch.h"
+#include "BenchmarkComponent.h"
+#include "ClassWithMultipleInterfaces.g.cpp"
+
+namespace winrt::BenchmarkComponent::implementation
+{
+    ClassWithMultipleInterfaces::ClassWithMultipleInterfaces()
+    {
+    }
+
+    int32_t ClassWithMultipleInterfaces::IntProperty1()
+    {
+        return 1;
+    }
+
+    void ClassWithMultipleInterfaces::IntProperty1(int32_t val)
+    {
+    }
+
+    bool ClassWithMultipleInterfaces::BoolProperty1()
+    {
+        return true;
+    }
+
+    void ClassWithMultipleInterfaces::BoolProperty1(bool val)
+    {
+    }
+
+    double ClassWithMultipleInterfaces::DoubleProperty1()
+    {
+        return 1;
+    }
+
+    void ClassWithMultipleInterfaces::DoubleProperty1(double val)
+    {
+    }
+
+    int32_t ClassWithMultipleInterfaces::IntProperty()
+    {
+        return 1;
+    }
+
+    bool ClassWithMultipleInterfaces::BoolProperty()
+    {
+        return false;
+    }
+
+    double ClassWithMultipleInterfaces::DoubleProperty()
+    {
+        return 1;
+    }
+
+    void ClassWithMultipleInterfaces::IntProperty(int32_t val)
+    {
+    }
+
+    void ClassWithMultipleInterfaces::BoolProperty(bool val)
+    {
+    }
+
+    void ClassWithMultipleInterfaces::DoubleProperty(double val)
+    {
+    }
+}

--- a/BenchmarkComponent/BenchmarkComponent.cpp
+++ b/BenchmarkComponent/BenchmarkComponent.cpp
@@ -8,44 +8,7 @@ namespace winrt::BenchmarkComponent::implementation
     {
     }
 
-    int32_t ClassWithMultipleInterfaces::IntProperty1()
-    {
-        return 1;
-    }
-
-    void ClassWithMultipleInterfaces::IntProperty1(int32_t val)
-    {
-    }
-
-    bool ClassWithMultipleInterfaces::BoolProperty1()
-    {
-        return true;
-    }
-
-    void ClassWithMultipleInterfaces::BoolProperty1(bool val)
-    {
-    }
-
-    double ClassWithMultipleInterfaces::DoubleProperty1()
-    {
-        return 1;
-    }
-
-    void ClassWithMultipleInterfaces::DoubleProperty1(double val)
-    {
-    }
-
     int32_t ClassWithMultipleInterfaces::IntProperty()
-    {
-        return 1;
-    }
-
-    bool ClassWithMultipleInterfaces::BoolProperty()
-    {
-        return false;
-    }
-
-    double ClassWithMultipleInterfaces::DoubleProperty()
     {
         return 1;
     }
@@ -54,11 +17,48 @@ namespace winrt::BenchmarkComponent::implementation
     {
     }
 
+    bool ClassWithMultipleInterfaces::BoolProperty()
+    {
+        return true;
+    }
+
     void ClassWithMultipleInterfaces::BoolProperty(bool val)
     {
     }
 
+    double ClassWithMultipleInterfaces::DoubleProperty()
+    {
+        return 1;
+    }
+
     void ClassWithMultipleInterfaces::DoubleProperty(double val)
+    {
+    }
+
+    int32_t ClassWithMultipleInterfaces::DefaultIntProperty()
+    {
+        return 1;
+    }
+
+    bool ClassWithMultipleInterfaces::DefaultBoolProperty()
+    {
+        return false;
+    }
+
+    double ClassWithMultipleInterfaces::DefaultDoubleProperty()
+    {
+        return 1;
+    }
+
+    void ClassWithMultipleInterfaces::DefaultIntProperty(int32_t val)
+    {
+    }
+
+    void ClassWithMultipleInterfaces::DefaultBoolProperty(bool val)
+    {
+    }
+
+    void ClassWithMultipleInterfaces::DefaultDoubleProperty(double val)
     {
     }
 }

--- a/BenchmarkComponent/BenchmarkComponent.def
+++ b/BenchmarkComponent/BenchmarkComponent.def
@@ -1,0 +1,3 @@
+﻿EXPORTS
+DllCanUnloadNow = WINRT_CanUnloadNow                    PRIVATE
+DllGetActivationFactory = WINRT_GetActivationFactory    PRIVATE

--- a/BenchmarkComponent/BenchmarkComponent.h
+++ b/BenchmarkComponent/BenchmarkComponent.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "ClassWithMultipleInterfaces.g.h"
+
+namespace winrt::BenchmarkComponent::implementation
+{
+    struct ClassWithMultipleInterfaces : ClassWithMultipleInterfacesT<ClassWithMultipleInterfaces>
+    {
+        ClassWithMultipleInterfaces();
+
+        int32_t IntProperty1();
+        void IntProperty1(int32_t val);
+
+        bool BoolProperty1();
+        void BoolProperty1(bool val);
+
+        double DoubleProperty1();
+        void DoubleProperty1(double val);
+
+        int32_t IntProperty();
+        bool BoolProperty();
+        double DoubleProperty();
+        void IntProperty(int32_t val);
+        void BoolProperty(bool val);
+        void DoubleProperty(double val);
+    };
+}
+
+namespace winrt::BenchmarkComponent::factory_implementation
+{
+    struct ClassWithMultipleInterfaces : ClassWithMultipleInterfacesT<ClassWithMultipleInterfaces, implementation::ClassWithMultipleInterfaces>
+    {
+    };
+}

--- a/BenchmarkComponent/BenchmarkComponent.h
+++ b/BenchmarkComponent/BenchmarkComponent.h
@@ -8,21 +8,21 @@ namespace winrt::BenchmarkComponent::implementation
     {
         ClassWithMultipleInterfaces();
 
-        int32_t IntProperty1();
-        void IntProperty1(int32_t val);
-
-        bool BoolProperty1();
-        void BoolProperty1(bool val);
-
-        double DoubleProperty1();
-        void DoubleProperty1(double val);
-
         int32_t IntProperty();
-        bool BoolProperty();
-        double DoubleProperty();
         void IntProperty(int32_t val);
+
+        bool BoolProperty();
         void BoolProperty(bool val);
+
+        double DoubleProperty();
         void DoubleProperty(double val);
+
+        int32_t DefaultIntProperty();
+        bool DefaultBoolProperty();
+        double DefaultDoubleProperty();
+        void DefaultIntProperty(int32_t val);
+        void DefaultBoolProperty(bool val);
+        void DefaultDoubleProperty(double val);
     };
 }
 

--- a/BenchmarkComponent/BenchmarkComponent.idl
+++ b/BenchmarkComponent/BenchmarkComponent.idl
@@ -1,0 +1,34 @@
+// Modern IDL 3.0: https://docs.microsoft.com/en-us/uwp/midl-3/intro
+
+// BenchmarkComponent exercises indivdual isolated scenarios we want to benchmark in a WinRT projection.
+
+namespace BenchmarkComponent
+{
+    interface IIntProperties
+    {
+        Int32 IntProperty1{ get; set; };
+    }
+
+    interface IBoolProperties
+    {
+        Boolean BoolProperty1{ get; set; };
+    }
+
+    interface IDoubleProperties
+    {
+        Double DoubleProperty1{ get; set; };
+    }
+
+    [default_interface]
+    runtimeclass ClassWithMultipleInterfaces :
+        IIntProperties
+        , IBoolProperties
+        , IDoubleProperties
+    {
+        ClassWithMultipleInterfaces();
+
+        Int32 IntProperty{ get; set; };
+        Boolean BoolProperty{ get; set; };
+        Double DoubleProperty{ get; set; };
+    }
+}

--- a/BenchmarkComponent/BenchmarkComponent.idl
+++ b/BenchmarkComponent/BenchmarkComponent.idl
@@ -19,6 +19,7 @@ namespace BenchmarkComponent
         Double DoubleProperty{ get; set; };
     }
 
+    // Class intended to help with benchmarking QueryInterface for the default and non default interfaces.
     [default_interface]
     runtimeclass ClassWithMultipleInterfaces :
         IIntProperties

--- a/BenchmarkComponent/BenchmarkComponent.idl
+++ b/BenchmarkComponent/BenchmarkComponent.idl
@@ -6,17 +6,17 @@ namespace BenchmarkComponent
 {
     interface IIntProperties
     {
-        Int32 IntProperty1{ get; set; };
+        Int32 IntProperty{ get; set; };
     }
 
     interface IBoolProperties
     {
-        Boolean BoolProperty1{ get; set; };
+        Boolean BoolProperty{ get; set; };
     }
 
     interface IDoubleProperties
     {
-        Double DoubleProperty1{ get; set; };
+        Double DoubleProperty{ get; set; };
     }
 
     [default_interface]
@@ -27,8 +27,8 @@ namespace BenchmarkComponent
     {
         ClassWithMultipleInterfaces();
 
-        Int32 IntProperty{ get; set; };
-        Boolean BoolProperty{ get; set; };
-        Double DoubleProperty{ get; set; };
+        Int32 DefaultIntProperty{ get; set; };
+        Boolean DefaultBoolProperty{ get; set; };
+        Double DefaultDoubleProperty{ get; set; };
     }
 }

--- a/BenchmarkComponent/BenchmarkComponent.vcxproj
+++ b/BenchmarkComponent/BenchmarkComponent.vcxproj
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTVerbosity>high</CppWinRTVerbosity>
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+    <ProjectGuid>{78d85f23-7cb1-44a1-9238-6df2c76754e4}</ProjectGuid>
+    <ProjectName>BenchmarkComponent</ProjectName>
+    <RootNamespace>BenchmarkComponent</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
+    <_NoWinAPIFamilyApp>true</_NoWinAPIFamilyApp>
+    <_VC_Target_Library_Platform>Desktop</_VC_Target_Library_Platform>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <ModuleDefinitionFile>BenchmarkComponent.def</ModuleDefinitionFile>
+    </Link>
+    <ClCompile>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="BenchmarkComponent.h">
+      <DependentUpon>BenchmarkComponent.idl</DependentUpon>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="BenchmarkComponent.cpp">
+      <DependentUpon>BenchmarkComponent.idl</DependentUpon>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="BenchmarkComponent.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="BenchmarkComponent.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200511.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
+</Project>

--- a/BenchmarkComponent/BenchmarkComponent.vcxproj.filters
+++ b/BenchmarkComponent/BenchmarkComponent.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resources">
+      <UniqueIdentifier>accd3aa8-1ba0-4223-9bbe-0c431709210b</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{926ab91d-31b4-48c3-b9a4-e681349f27f0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="BenchmarkComponent.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="BenchmarkComponent.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="BenchmarkComponent.def" />
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/BenchmarkComponent/packages.config
+++ b/BenchmarkComponent/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.200511.2" targetFramework="native" />
+</packages>

--- a/BenchmarkComponent/pch.cpp
+++ b/BenchmarkComponent/pch.cpp
@@ -1,0 +1,1 @@
+﻿#include "pch.h"

--- a/BenchmarkComponent/pch.h
+++ b/BenchmarkComponent/pch.h
@@ -1,0 +1,4 @@
+﻿#pragma once
+#include <unknwn.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>

--- a/Test.sln
+++ b/Test.sln
@@ -10,6 +10,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Console", "Console\Console.
 		{2954F343-85A7-46F5-A3F3-F106FDD13900} = {2954F343-85A7-46F5-A3F3-F106FDD13900}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BenchmarkComponent", "BenchmarkComponent\BenchmarkComponent.vcxproj", "{78D85F23-7CB1-44A1-9238-6DF2C76754E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -42,6 +44,18 @@ Global
 		{8AB80BFD-185A-452D-AAD2-97B38AED3E4B}.Release|x64.Build.0 = Release|x64
 		{8AB80BFD-185A-452D-AAD2-97B38AED3E4B}.Release|x86.ActiveCfg = Release|Win32
 		{8AB80BFD-185A-452D-AAD2-97B38AED3E4B}.Release|x86.Build.0 = Release|Win32
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Debug|ARM.ActiveCfg = Debug|ARM
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Debug|ARM.Build.0 = Debug|ARM
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Debug|x64.ActiveCfg = Debug|x64
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Debug|x64.Build.0 = Debug|x64
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Debug|x86.ActiveCfg = Debug|Win32
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Debug|x86.Build.0 = Debug|Win32
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Release|ARM.ActiveCfg = Release|ARM
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Release|ARM.Build.0 = Release|ARM
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Release|x64.ActiveCfg = Release|x64
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Release|x64.Build.0 = Release|x64
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Release|x86.ActiveCfg = Release|Win32
+		{78D85F23-7CB1-44A1-9238-6DF2C76754E4}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adding a separate component from the test component meant to be used to exercise scenarios that we would want to benchmark in a projection.  I am intentionally keeping this component separate from the test component as I want to ensure that benchmarks collected using this component can be stored by each projection using it if desired and compared with past results without worrying that there might be changes made to the component which might affect the results and be uncomparable.  Over time I expect we would build this component additively with new classes that exercises other areas we would want to benchmark.  Currently I have a class with multiple interfaces implemented on it which enables benchmarking of QueryInterface for the default interface and for the non default interfaces from a consuming projection.