### PR TITLE
Add custom attribute with named arguments to TestRunner

### DIFF
--- a/TestComponent/TestComponent.idl
+++ b/TestComponent/TestComponent.idl
@@ -183,6 +183,15 @@ namespace TestComponent
 
     delegate void TestHandler(ITests tests);
 
+    [attributeusage(target_runtimeclass)]
+    attribute CustomTestAttribute
+    {
+        String SomeString;
+        Int32 SomeInt;
+        Boolean SomeBool;
+    }
+
+    [CustomTest("Hello, World!", 1975, TRUE)]
     runtimeclass TestRunner
     {
         // Throws an exception if ITests is not implemented correctly.

--- a/TestComponent/TestComponent.nuspec
+++ b/TestComponent/TestComponent.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>KennyKerr.Windows.TestWinRT</id>
-    <version>1.0.16</version>
+    <version>1.0.17</version>
     <title>TestWinRT</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
In pursuit of being able to test https://github.com/microsoft/winrt-rs/pull/261, I added a custom attribute with named arguments and marked the `TestRunner` class with it.

I ran the Console project, and it passed. Please let me know if there are more tests I should run!