### PR TITLE
Derived composable test class

### DIFF
--- a/TestComponent/Composable.cpp
+++ b/TestComponent/Composable.cpp
@@ -13,4 +13,24 @@ namespace winrt::TestComponent::implementation
     {
         return m_value;
     }
+
+    int32_t Composable::One()
+    {
+        return 1;
+    }
+
+    int32_t Composable::Two()
+    {
+        return 2;
+    }
+
+    int32_t Composable::Three()
+    {
+        return 3;
+    }
+
+    int32_t Composable::Four()
+    {
+        return 4;
+    }
 }

--- a/TestComponent/Composable.h
+++ b/TestComponent/Composable.h
@@ -11,6 +11,11 @@ namespace winrt::TestComponent::implementation
         int32_t Value();
 
         int32_t m_value{};
+
+        int32_t One();
+        int32_t Two();
+        int32_t Three();
+        int32_t Four();
     };
 }
 

--- a/TestComponent/Derived.cpp
+++ b/TestComponent/Derived.cpp
@@ -1,0 +1,7 @@
+#include "pch.h"
+#include "Derived.h"
+#include "Derived.g.cpp"
+
+namespace winrt::TestComponent::implementation
+{
+}

--- a/TestComponent/Derived.h
+++ b/TestComponent/Derived.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Derived.g.h"
+#include "Composable.h"
+
+namespace winrt::TestComponent::implementation
+{
+    struct Derived : DerivedT<Derived, TestComponent::implementation::Composable>
+    {
+        Derived() = default;
+    };
+}
+namespace winrt::TestComponent::factory_implementation
+{
+    struct Derived : DerivedT<Derived, implementation::Derived>
+    {
+    };
+}

--- a/TestComponent/TestComponent.idl
+++ b/TestComponent/TestComponent.idl
@@ -205,7 +205,27 @@ namespace TestComponent
         static Windows.Foundation.IAsyncAction CreateAsyncAction(UInt32 milliseconds);
     }
 
-    unsealed runtimeclass Composable
+    interface IRequiredOne
+    {
+        Int32 One();
+    };
+
+    interface IRequiredTwo requires IRequiredOne
+    {
+        Int32 Two();
+    };
+
+    interface IRequiredThree requires IRequiredOne, IRequiredTwo
+    {
+        Int32 Three();
+    };
+
+    interface IRequiredFour requires IRequiredOne, IRequiredTwo, IRequiredThree
+    {
+        Int32 Four();
+    };
+
+    unsealed runtimeclass Composable : IRequiredOne, IRequiredTwo, IRequiredThree, IRequiredFour
     {
         Composable();
 
@@ -213,5 +233,10 @@ namespace TestComponent
         Composable(Int32 init);
 
         Int32 Value{ get; };
+    }
+
+    unsealed runtimeclass Derived : Composable, IRequiredOne, IRequiredTwo, IRequiredThree, IRequiredFour
+    {
+        Derived();
     }
 }

--- a/TestComponent/TestComponent.nuspec
+++ b/TestComponent/TestComponent.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>KennyKerr.Windows.TestWinRT</id>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <title>TestWinRT</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/TestComponent/TestComponent.vcxproj
+++ b/TestComponent/TestComponent.vcxproj
@@ -127,11 +127,13 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Composable.h" />
+    <ClInclude Include="Derived.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="TestRunner.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Composable.cpp" />
+    <ClCompile Include="Derived.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/TestComponent/TestComponent.vcxproj.filters
+++ b/TestComponent/TestComponent.vcxproj.filters
@@ -14,11 +14,13 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="TestRunner.cpp" />
     <ClCompile Include="Composable.cpp" />
+    <ClCompile Include="Derived.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
     <ClInclude Include="TestRunner.h" />
     <ClInclude Include="Composable.h" />
+    <ClInclude Include="Derived.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="TestComponent.idl" />


### PR DESCRIPTION
This specifically tests required classes in composable hierarchies to ensure that the language projection properly folds duplicates.