### PR TITLE
Add fast abi test component

### DIFF
--- a/Test.sln
+++ b/Test.sln
@@ -19,6 +19,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_component_derived", "t
 		{13333A6F-6A4A-48CD-865C-0F65135EB018} = {13333A6F-6A4A-48CD-865C-0F65135EB018}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_component_fast", "test_component_fast\test_component_fast.vcxproj", "{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -87,6 +89,18 @@ Global
 		{0080F6D1-AEC3-4F89-ADE1-3D22A7EBF99E}.Release|x64.Build.0 = Release|x64
 		{0080F6D1-AEC3-4F89-ADE1-3D22A7EBF99E}.Release|x86.ActiveCfg = Release|Win32
 		{0080F6D1-AEC3-4F89-ADE1-3D22A7EBF99E}.Release|x86.Build.0 = Release|Win32
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Debug|ARM.ActiveCfg = Debug|ARM
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Debug|ARM.Build.0 = Debug|ARM
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Debug|x64.ActiveCfg = Debug|x64
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Debug|x64.Build.0 = Debug|x64
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Debug|x86.ActiveCfg = Debug|Win32
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Debug|x86.Build.0 = Debug|Win32
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Release|ARM.ActiveCfg = Release|ARM
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Release|ARM.Build.0 = Release|ARM
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Release|x64.ActiveCfg = Release|x64
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Release|x64.Build.0 = Release|x64
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Release|x86.ActiveCfg = Release|Win32
+		{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test_component_fast/Composition.CompositionObject.cpp
+++ b/test_component_fast/Composition.CompositionObject.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "Composition.CompositionObject.h"
+#include "Composition.CompositionObject.g.cpp"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    CompositionObject::CompositionObject(Composition::Compositor const& compositor) :
+        m_compositor(compositor)
+    {
+    }
+
+    void CompositionObject::Close()
+    {
+    }
+    Compositor CompositionObject::Compositor()
+    {
+        return m_compositor;
+    }
+    void CompositionObject::StartAnimationGroup()
+    {
+    }
+}

--- a/test_component_fast/Composition.CompositionObject.h
+++ b/test_component_fast/Composition.CompositionObject.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Composition.CompositionObject.g.h"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    struct CompositionObject : CompositionObjectT<CompositionObject>
+    {
+        CompositionObject(Composition::Compositor const& compositor);
+
+        void Close();
+        Composition::Compositor Compositor();
+        void StartAnimationGroup();
+
+    protected:
+
+        Composition::Compositor m_compositor{ nullptr };
+    };
+}

--- a/test_component_fast/Composition.Compositor.cpp
+++ b/test_component_fast/Composition.Compositor.cpp
@@ -1,0 +1,12 @@
+#include "pch.h"
+#include "Composition.Compositor.h"
+#include "Composition.Compositor.g.cpp"
+#include "Composition.SpriteVisual.h"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    Composition::SpriteVisual Compositor::CreateSpriteVisual()
+    {
+        return make<SpriteVisual>(*this);
+    }
+}

--- a/test_component_fast/Composition.Compositor.h
+++ b/test_component_fast/Composition.Compositor.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Composition.Compositor.g.h"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    struct Compositor : CompositorT<Compositor>
+    {
+        Compositor() = default;
+
+        SpriteVisual CreateSpriteVisual();
+    };
+}
+namespace winrt::test_component_fast::Composition::factory_implementation
+{
+    struct Compositor : CompositorT<Compositor, implementation::Compositor>
+    {
+    };
+}

--- a/test_component_fast/Composition.SpriteVisual.cpp
+++ b/test_component_fast/Composition.SpriteVisual.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "Composition.SpriteVisual.h"
+#include "Composition.SpriteVisual.g.cpp"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    SpriteVisual::SpriteVisual(Composition::Compositor const& compositor) :
+        base_type(compositor)
+    {
+
+    }
+    void SpriteVisual::Brush()
+    {
+    }
+    void SpriteVisual::Shadow()
+    {
+    }
+}

--- a/test_component_fast/Composition.SpriteVisual.h
+++ b/test_component_fast/Composition.SpriteVisual.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "Composition.SpriteVisual.g.h"
+#include "Composition.Visual.h"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    struct SpriteVisual : SpriteVisualT<SpriteVisual, implementation::Visual>
+    {
+        SpriteVisual(Composition::Compositor const& compositor);
+
+        void Brush();
+        void Shadow();
+    };
+}

--- a/test_component_fast/Composition.Visual.cpp
+++ b/test_component_fast/Composition.Visual.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "Composition.Visual.h"
+#include "Composition.Visual.g.cpp"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    Visual::Visual(Composition::Compositor const& compositor) :
+        base_type(compositor)
+    {
+    }
+    void Visual::Offset(int32_t value)
+    {
+        m_offset = value;
+    }
+    int32_t Visual::Offset()
+    {
+        return m_offset;
+    }
+    void Visual::ParentForTransform([[maybe_unused]] Composition::Visual const& value)
+    {
+    }
+}

--- a/test_component_fast/Composition.Visual.h
+++ b/test_component_fast/Composition.Visual.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Composition.Visual.g.h"
+#include "Composition.CompositionObject.h"
+
+namespace winrt::test_component_fast::Composition::implementation
+{
+    struct Visual : VisualT<Visual, implementation::CompositionObject>
+    {
+        Visual(Composition::Compositor const& compositor);
+
+        int32_t Offset();
+        void Offset(int32_t value);
+        void ParentForTransform(Composition::Visual const& value);
+
+    private:
+
+        int32_t m_offset{};
+    };
+}

--- a/test_component_fast/Simple.cpp
+++ b/test_component_fast/Simple.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "Simple.h"
+#include "Simple.g.cpp"
+
+// Validates that WINRT_FAST_ABI_SIZE may be overridden using /D.
+#pragma detect_mismatch("WINRT_FAST_ABI_SIZE", "50")
+
+namespace winrt::test_component_fast::implementation
+{
+    hstring Simple::Method1()
+    {
+        return L"Method1";
+    }
+    hstring Simple::Method2()
+    {
+        return L"Method2";
+    }
+    hstring Simple::Method3()
+    {
+        return L"Method3";
+    }
+}

--- a/test_component_fast/Simple.h
+++ b/test_component_fast/Simple.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "Simple.g.h"
+
+namespace winrt::test_component_fast::implementation
+{
+    struct Simple : SimpleT<Simple>
+    {
+        Simple() = default;
+
+        hstring Method1();
+        hstring Method2();
+        hstring Method3();
+    };
+}
+namespace winrt::test_component_fast::factory_implementation
+{
+    struct Simple : SimpleT<Simple, implementation::Simple>
+    {
+    };
+}

--- a/test_component_fast/exports.def
+++ b/test_component_fast/exports.def
@@ -1,0 +1,3 @@
+EXPORTS
+DllCanUnloadNow = WINRT_CanUnloadNow                    PRIVATE
+DllGetActivationFactory = WINRT_GetActivationFactory    PRIVATE

--- a/test_component_fast/pch.cpp
+++ b/test_component_fast/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/test_component_fast/pch.h
+++ b/test_component_fast/pch.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "winrt/fast_forward.h"

--- a/test_component_fast/test_component_fast.idl
+++ b/test_component_fast/test_component_fast.idl
@@ -1,0 +1,131 @@
+namespace test_component_fast
+{
+    [contractversion(4)]
+    apicontract SimpleContract{};
+
+    [fastabi(SimpleContract, 1)]
+    [contract(SimpleContract, 1)]
+    runtimeclass Simple
+    {
+        Simple();
+
+        String Method1();
+
+        [contract(SimpleContract, 1.2)]
+        {
+            String Method2();
+        }
+
+        [contract(SimpleContract, 2.1)]
+        {
+            String Method3();
+        }
+    }
+
+    namespace Composition
+    {
+        [contractversion(4)]
+        apicontract FastContract{};
+
+        runtimeclass Visual;
+        runtimeclass Compositor;
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [exclusiveto(CompositionObject)]
+        [uuid(51205C5E-558A-4F2A-8D39-37BFE1E20DDD)]
+        interface ICompositionObjectFactory
+        {
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [exclusiveto(Visual)]
+        [uuid(AD0FF93E-B502-4EB5-87B4-9A38A71D0137)]
+        interface IVisualFactory
+        {
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [exclusiveto(CompositionObject)]
+        interface ICompositionObject
+        {
+            [noexcept] Compositor Compositor();
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 3.0)]
+        [exclusiveto(CompositionObject)]
+        interface ICompositionObject2
+        {
+            [noexcept] void StartAnimationGroup();
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [exclusiveto(Visual)]
+        interface IVisual
+        {
+            [noexcept] Int32 Offset{ get; set; };
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 4.0)]
+        [exclusiveto(Visual)]
+        interface IVisual2
+        {
+            [noexcept] void ParentForTransform(test_component_fast.Composition.Visual value);
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [exclusiveto(SpriteVisual)]
+        interface ISpriteVisual
+        {
+            [noexcept] void Brush();
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 3.0)]
+        [exclusiveto(SpriteVisual)]
+        interface ISpriteVisual2
+        {
+            [noexcept] void Shadow();
+        }
+
+        [composable(test_component_fast.Composition.ICompositionObjectFactory, protected, test_component_fast.Composition.FastContract, 2.0)]
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [marshaling_behavior(agile)]
+        [threading(both)]
+        [fastabi(test_component_fast.Composition.FastContract, 2.0)]
+        runtimeclass CompositionObject
+        {
+            [default] interface test_component_fast.Composition.ICompositionObject;
+            
+            [contract(test_component_fast.Composition.FastContract, 3.0)] interface test_component_fast.Composition.ICompositionObject2;
+        }
+
+        [composable(test_component_fast.Composition.IVisualFactory, protected, test_component_fast.Composition.FastContract, 2.0)]
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [marshaling_behavior(agile)]
+        [threading(both)]
+        [fastabi(test_component_fast.Composition.FastContract, 2.0)]
+        runtimeclass Visual : test_component_fast.Composition.CompositionObject
+        {
+            [default] interface test_component_fast.Composition.IVisual;
+            [contract(test_component_fast.Composition.FastContract, 4.0)] interface test_component_fast.Composition.IVisual2;
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [marshaling_behavior(agile)]
+        [threading(both)]
+        [fastabi(test_component_fast.Composition.FastContract, 2.0)]
+        runtimeclass SpriteVisual : test_component_fast.Composition.Visual
+        {
+            [default] interface test_component_fast.Composition.ISpriteVisual;
+            [contract(test_component_fast.Composition.FastContract, 3.0)] interface test_component_fast.Composition.ISpriteVisual2;
+        }
+
+        [contract(test_component_fast.Composition.FastContract, 2.0)]
+        [fastabi(test_component_fast.Composition.FastContract, 2.0)]
+        runtimeclass Compositor
+        {
+            Compositor();
+
+            [noexcept] test_component_fast.Composition.SpriteVisual CreateSpriteVisual();
+        }
+    }
+}

--- a/test_component_fast/test_component_fast.vcxproj
+++ b/test_component_fast/test_component_fast.vcxproj
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTFastAbi>true</CppWinRTFastAbi>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{0E0ACA62-A92F-44CF-BD41-AEB541946DF8}</ProjectGuid>
+    <ProjectName>test_component_fast</ProjectName>
+    <RootNamespace>test_component_fast</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<OutDir>$(SolutionDir)x64\$(Configuration)\$(ProjectName)</OutDir>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<OutDir>$(SolutionDir)x64\$(Configuration)\$(ProjectName)</OutDir>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<OutDir>$(SolutionDir)x86\$(Configuration)\$(ProjectName)</OutDir>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<OutDir>$(SolutionDir)x86\$(Configuration)\$(ProjectName)</OutDir>
+	</PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
+      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204</DisableSpecificWarnings>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/DWINRT_FAST_ABI_SIZE=50 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">copy $(OutDir)$(ProjectName).winmd $(SolutionDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">copy $(OutDir)$(ProjectName).winmd $(SolutionDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy $(OutDir)$(ProjectName).winmd $(SolutionDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/DWINRT_FAST_ABI_SIZE=50 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">copy $(OutDir)$(ProjectName).winmd $(SolutionDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">copy $(OutDir)$(ProjectName).winmd $(SolutionDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">copy $(OutDir)$(ProjectName).winmd $(SolutionDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="Composition.CompositionObject.h" />
+    <ClInclude Include="Composition.Compositor.h" />
+    <ClInclude Include="Composition.SpriteVisual.h" />
+    <ClInclude Include="Composition.Visual.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="Simple.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Composition.CompositionObject.cpp" />
+    <ClCompile Include="Composition.Compositor.cpp" />
+    <ClCompile Include="Composition.SpriteVisual.cpp" />
+    <ClCompile Include="Composition.Visual.cpp" />
+    <ClCompile Include="Simple.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="test_component_fast.idl">
+      <AdditionalOptions>/fastabi %(AdditionalOptions)</AdditionalOptions>
+    </Midl>
+  </ItemGroup>
+  <ItemGroup>
+	<None Include="packages.config" />
+  <None Include="exports.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
+	<Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.201113.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
+</Project>


### PR DESCRIPTION
This PR adds a test component to test fast abi consumption. The contents of the test component are copied from cppwinrt/test_component_fast