### PR TITLE
Fix the build with VS2022

### DIFF
--- a/Console/Console.vcxproj
+++ b/Console/Console.vcxproj
@@ -33,9 +33,7 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/TestComponent/TestComponent.vcxproj
+++ b/TestComponent/TestComponent.vcxproj
@@ -42,9 +42,7 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test_component_base/test_component_base.vcxproj
+++ b/test_component_base/test_component_base.vcxproj
@@ -42,9 +42,7 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test_component_derived/test_component_derived.vcxproj
+++ b/test_component_derived/test_component_derived.vcxproj
@@ -45,9 +45,7 @@
 	</ItemGroup>
 	<PropertyGroup Label="Configuration">
 		<ConfigurationType>DynamicLibrary</ConfigurationType>
-		<PlatformToolset>v140</PlatformToolset>
-		<PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-		<PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+		<PlatformToolset>v142</PlatformToolset>
 		<CharacterSet>Unicode</CharacterSet>
 		<GenerateManifest>false</GenerateManifest>
 	</PropertyGroup>


### PR DESCRIPTION
VS2022 has VisualStudioVersion=17.0 that was unhandled in the project files and falling back to VS2015 build tools.

I have fixed this by deleting the fallback to VS2015/2017 build tools since it does not seem to work anyway.